### PR TITLE
allow execution via `mix run`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ rel/erl-dns
 zones.json
 .eunit/
 db/
+_build/

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,23 @@
+use Mix.Config
+
+config :erldns,
+  storage: [type: :erldns_storage_mnesia, dir: 'db', dbname: :undefined, user: :undefined, pass: :undefined, host: :undefined, port: :undefined],
+  servers: [
+    [name: :inet_localhost_1, address: '127.0.0.1', port: 8053, family: :inet, processes: 2],
+    [name: :inet6_localhost_1, address: '::1', port: 8053, family: :inet6],
+  ],
+  use_root_hints: false,
+  catch_exceptions: false,
+  zones: 'priv/example.zone.json',
+  metrics: [ port: 8082 ],
+  admin: [ port: 8083, credentials: {'username', 'password'} ],
+  pools: [
+    {:tcp_worker_pool, :erldns_worker, [ size: 10, max_overflow: 20 ] }
+  ]
+
+config :lager,
+  handlers: [
+    lager_file_backend: [file: 'log/debug.log', level: :debug, size: 204857600, count: 5]
+  ]
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/mix.exs
+++ b/mix.exs
@@ -41,13 +41,12 @@ defmodule ErlDns.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:lager, github: "basho/lager"},
-      {:recon, github: "ferd/recon", tag: "2.2.1"},
-      {:folsom, github: "boundary/folsom"},
-      {:poolboy, github: "devinus/poolboy"},
-      {:jsx, github: "talentdeficit/jsx"},
+      {:lager, "~> 3.0"},
+      {:recon, "~> 2.2"},
+      {:folsom, "~> 0.8"},
+      {:poolboy, "~> 1.5"},
+      {:jsx, "~> 2.8"},
       {:dns, github: "aetrion/dns_erlang"},
-
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{"base32": {:git, "https://github.com/aetrion/base32_erlang.git", "40431a7480176b24863e18b92d9872e54c714df5", [ref: "master"]},
-  "bear": {:git, "git://github.com/boundary/bear.git", "119234548783af19b8ec75c879c5062676b92571", [tag: "0.8.2"]},
+  "bear": {:hex, :bear, "0.8.3"},
   "dns": {:git, "https://github.com/aetrion/dns_erlang.git", "674603aec44a2f3fda1f42dd93d1c1368ac319ca", []},
-  "folsom": {:git, "https://github.com/boundary/folsom.git", "8914823067c623d2839ecd6d17785ba94ad004c8", []},
-  "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "212299233c7e7eb63a97be2777e1c05ebaa58dbe", [tag: "0.1.8"]},
-  "jsx": {:git, "https://github.com/talentdeficit/jsx.git", "3074d4865b3385a050badf7828ad31490d860df5", []},
-  "lager": {:git, "https://github.com/basho/lager.git", "b2cb2735713e3021e0761623ff595d53a545438e", []},
+  "folsom": {:hex, :folsom, "0.8.3"},
+  "goldrush": {:hex, :goldrush, "0.1.7"},
+  "jsx": {:hex, :jsx, "2.8.0"},
+  "lager": {:hex, :lager, "3.0.2"},
   "meck": {:git, "git://github.com/eproxus/meck", "dde759050eff19a1a80fd854d7375174b191665d", [tag: "0.8.2"]},
-  "poolboy": {:git, "https://github.com/devinus/poolboy.git", "3bb3972617b3706b7fda6e264bf6bdaefbb833cd", []},
-  "recon": {:git, "https://github.com/ferd/recon.git", "3578fa86ad408d98e0512ded0b2f2c5b834a84ad", [tag: "2.2.1"]}}
+  "poolboy": {:hex, :poolboy, "1.5.1"},
+  "recon": {:hex, :recon, "2.2.1"}}


### PR DESCRIPTION
Prior to this commit erl-dns would need to be run with the packaged
`run.sh` script, which would need to be updated with the ebin
locations for the locally installed Elixir. This commit converts the
`erldns.config.example` into a mix config that is read during
compilation and included in the app, which enables erl-dns to now be run
via `mix run --no-halt` or `iex -S mix run`.
